### PR TITLE
Implemented "ignore_year" option and various fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -39,6 +39,13 @@ config = [{
                     'type': 'int',
                     'default': 40,
                     'description': 'Will not be (re)moved until this seed time (in hours) is met.',
+                },
+		{
+                    'name': 'ignore_year',
+                    'label': 'Ignore year',
+                    'default': 0,
+                    'type': 'bool',
+                    'description': 'Will ignore the year in the search results',
                 }
             ],
         },


### PR DESCRIPTION
- implemented "ignore_year" option (it needs to be enabled in the searcher configuration)
- fixed parsing of torrents with "n/a" seeders, in this case now it assumes there's "1" seeder instead of ignoring the torrent, as it happens frequently on ilcorsaronero, but the torrents actually have seeders.
- fixes https://github.com/bateman/corsaronero-cp-provider/issues/10